### PR TITLE
Updated Readme.md to Include link to Netduino Library repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ All text above must be included in any redistribution
 To download. click the DOWNLOADS button in the top right corner, rename the uncompressed folder Adafruit_RGBLCDShield. Check that the Adafruit_RGBLCDShield folder contains Adafruit_RGBLCDShield.cpp and Adafruit_RGBLCDShield.h
 
 Place the Adafruit_RGBLCDShield library folder your <arduinosketchfolder>/libraries/ folder. You may need to create the libraries subfolder if its your first library. Restart the IDE.
+
+Visit this [Github repo] (https://github.com/giawa/rgbshield4netduino.git) for code to use the RGB LCD Shield with Netduino devices.


### PR DESCRIPTION
Would you consider adding a link to https://github.com/giawa/rgbshield4netduino.git for use on your device with a Netduino?  
I have created a branch under my forked copy from Giawa (referenced in his Readme.md) that uses events (as opposed to loops) to collect user input.