### PR TITLE
Update Adafruit_RGBLCDShield.h

### DIFF
--- a/Adafruit_RGBLCDShield.h
+++ b/Adafruit_RGBLCDShield.h
@@ -60,7 +60,7 @@
 /*!
  * @brief Base class for RGB LCD shield
  */
-class Adafruit_RGBLCDShield : public Print {
+class Adafruit_RGBLCDShield : public arduino::Print {
 public:
   Adafruit_RGBLCDShield();
 


### PR DESCRIPTION
The current library does not work with the Arduino Uno Wifi Rev 2. My understanding from the product page was that it was supposed to.
Even compiling the hello world sample doesn't work. 

I investigated the source code for Print (since the library is a member of that class) and noticed that the megaavr boards (of which wifi rev 2 is one, but uno rev 3 is not) have Print identified within the "arduino" namespace. More details in my forum post here: https://forums.adafruit.com/viewtopic.php?f=25&t=166228

So, by adding the namespace declaration in the header file, I got the library to work. It also compiles and runs on uno rev 3 as well. I thought this might be helpful for others.

